### PR TITLE
fix(#9): fixed bug with duplicate nodes

### DIFF
--- a/data/node.py
+++ b/data/node.py
@@ -43,5 +43,5 @@ class Node:
         return True
 
     def __hash__(self) -> int:
-        return hash(self.__id)
+        return hash(f"{self.__field}{self.__name}")
     


### PR DESCRIPTION
Fixed duplicate bug by hashing with field and label instead of guid.

GUID are only to be used to link nodes and edges.